### PR TITLE
use fish builtin function instead

### DIFF
--- a/functions/fish_right_prompt.fish
+++ b/functions/fish_right_prompt.fish
@@ -10,7 +10,7 @@ function fish_right_prompt
       set_color normal
       set_color -b purple
       set_color -o black
-      printf ' %s' (git branch ^/dev/null | sed -n '/\* /s///p')
+      printf ' %s' (fish_git_prompt | sed 's|[(),]||g')
       set_color normal
       set_color purple
     else


### PR DESCRIPTION
to prevent the message "^/dev/null is not a valid branch name" at each command inside a git folder.